### PR TITLE
Added estimateSmartFee JSON-RPC call support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -162,6 +162,7 @@ RpcClient.callspec = {
   dumpPrivKey: '',
   encryptWallet: '',
   estimateFee: 'int',
+  estimateSmartFee: 'int str',
   estimatePriority: 'int',
   generate: 'int',
   getAccount: '',


### PR DESCRIPTION
Latest version of Litecoin support estimateSmartFee API now. This pull request is intended to support this API.